### PR TITLE
Remove redundant require('process')

### DIFF
--- a/exec.js
+++ b/exec.js
@@ -1,1 +1,1 @@
-setTimeout(function() { return true; }, require('process').argv[2]);
+setTimeout(function() { return true; }, process.argv[2]);


### PR DESCRIPTION
`process` is a global object and does not require the use of `require`. This appears not to work on Node 0.12 at all and therefore breaks Travis builds that use this Node version.

process.execSync was added in Node v0.11.12 so that would seem to be the base-version for this module.
