### PR TITLE
Add quotes around execPath for paths with spaces

### DIFF
--- a/module.js
+++ b/module.js
@@ -26,7 +26,7 @@ module.exports = interval => {
 		)
 	} catch (notAsync) { /* https://github.com/jochemstoel/nodejs-system-sleep/issues/4 */
 		require('child_process').execSync(
-			'"' + process.execPath + '"' + " -e \"setTimeout(function () { return true; }, " + interval + ");\""
+			`"${process.execPath}"` + " -e \"setTimeout(function () { return true; }, " + interval + ");\""
 		)
 		return null
 	}

--- a/module.js
+++ b/module.js
@@ -8,7 +8,7 @@
 
 const sleep = interval => new Promise((deliver, renege) => {
 	try {
-		setTimeout(()=>{
+		setTimeout(() => {
 			deliver(
 				new Date().getTime()
 			)
@@ -26,7 +26,7 @@ module.exports = interval => {
 		)
 	} catch (notAsync) { /* https://github.com/jochemstoel/nodejs-system-sleep/issues/4 */
 		require('child_process').execSync(
-			process.execPath + " -e \"setTimeout(function () { return true; }, " + interval + ");\""
+			'"' + process.execPath + '"' + " -e \"setTimeout(function () { return true; }, " + interval + ");\""
 		)
 		return null
 	}


### PR DESCRIPTION
I was playing around with this on my Windows box today and noticed that it was getting choked up on a path in the form ```C:\Program Files\...\node```, trying to execute ```C:\Program``` as an executable. This is pretty simple fix, tested on both Windows and Linux.